### PR TITLE
RailApp からのリクエストを許可する設定を追加する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'rails', '~> 5.1.3'
 gem 'sqlite3'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
+gem 'rack-cors', :require => 'rack/cors'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       mini_portile2 (~> 2.2.0)
     puma (3.9.1)
     rack (2.0.3)
+    rack-cors (1.0.2)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.1.3)
@@ -124,6 +125,7 @@ DEPENDENCIES
   byebug
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.7)
+  rack-cors
   rails (~> 5.1.3)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,13 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
+  # クロスドメインを許可する設定
+  config.middleware.insert_before ActionDispatch::Static, Rack::Cors do
+    allow do
+      origins 'http://localhost:3030'
+      resource '*', :headers => :any, :methods => [:get, :post, :delete]
+    end
+  end
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true


### PR DESCRIPTION
#29 の対応
develop環境下の設定に ajax から送信された RailApi(locahost:3000) へのリクエストを許可する設定を追加
これにより RailApp を http://localhost:3030 で立ち上げ、RailApi の機能を使用できようになる予定